### PR TITLE
kubernetes-debug

### DIFF
--- a/kubernetes-debug/debug-agent.yaml
+++ b/kubernetes-debug/debug-agent.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: debug-agent
+  name: debug-agent
+spec:
+  selector:
+    matchLabels:
+      app: debug-agent
+  template:
+    metadata:
+      labels:
+        app: debug-agent
+    spec:
+      containers:
+      - image: aylei/debug-agent:0.1.1
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 10027
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: debug-agent
+        ports:
+        - containerPort: 10027
+          hostPort: 10027
+          name: http
+          protocol: TCP
+        volumeMounts:
+        - name: docker
+          mountPath: "/var/run/docker.sock"
+      hostNetwork: true
+      volumes:
+      - name: docker
+        hostPath:
+          path: /var/run/docker.sock
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 5
+    type: RollingUpdate

--- a/kubernetes-debug/kit/deploy-netperf/cr.yaml
+++ b/kubernetes-debug/kit/deploy-netperf/cr.yaml
@@ -1,0 +1,5 @@
+
+apiVersion: "app.example.com/v1alpha1"
+kind: "Netperf"
+metadata:
+  name: "example"

--- a/kubernetes-debug/kit/deploy-netperf/crd.yaml
+++ b/kubernetes-debug/kit/deploy-netperf/crd.yaml
@@ -1,0 +1,13 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: netperfs.app.example.com
+spec:
+  group: app.example.com
+  names:
+    kind: Netperf
+    listKind: NetperfList
+    plural: netperfs
+    singular: netperf
+  scope: Namespaced
+  version: v1alpha1

--- a/kubernetes-debug/kit/deploy-netperf/operator.yaml
+++ b/kubernetes-debug/kit/deploy-netperf/operator.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: netperf-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: netperf-operator
+  template:
+    metadata:
+      labels:
+        name: netperf-operator
+    spec:
+      containers:
+        - name: netperf-operator
+          image: tailoredcloud/netperf-operator:v0.1.1-742a3e1
+
+
+          command:
+          - netperf-operator
+          imagePullPolicy: Always
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace

--- a/kubernetes-debug/kit/deploy-netperf/rbac.yaml
+++ b/kubernetes-debug/kit/deploy-netperf/rbac.yaml
@@ -1,0 +1,30 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: netperf-operator
+rules:
+- apiGroups:
+  - app.example.com
+  resources:
+  - "*"
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - "*"
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: default-account-netperf-operator
+subjects:
+- kind: ServiceAccount
+  name: default
+roleRef:
+  kind: Role
+  name: netperf-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes-debug/kit/iptables-tailer.yaml
+++ b/kubernetes-debug/kit/iptables-tailer.yaml
@@ -1,0 +1,48 @@
+---
+  apiVersion: apps/v1
+  kind: "DaemonSet"
+  metadata: 
+    name: "kube-iptables-tailer"
+    namespace: "kube-system"
+  spec: 
+    selector:
+      matchLabels:
+        app: "kube-iptables-tailer"
+    template:
+      metadata:
+        labels:
+          app: "kube-iptables-tailer"
+      spec: 
+        serviceAccountName: kube-iptables-tailer
+        containers: 
+          - name: "kube-iptables-tailer"
+            command:
+              - "/kube-iptables-tailer"
+              - "--log_dir=/my-service-logs" # change the output directory of service logs
+              - "--v=4" # enable V-leveled logging at this level
+            env: 
+              - name: "JOURNAL_DIRECTORY"
+                value: "/var/log/journal/"
+              - name: "POD_IDENTIFIER"
+                value: "label"
+              - name: "POD_IDENTIFIER_LABEL"
+                value: "netperf-type"
+              - name: "IPTABLES_LOG_PREFIX"
+                # log prefix defined in your iptables chains
+                value: "calico-packet:"
+            image: "virtualshuric/kube-iptables-tailer:8d4296a"
+            imagePullPolicy: Always
+            volumeMounts: 
+              - name: "iptables-logs"
+                mountPath: "/var/log/"
+                readOnly: true
+              - name: "service-logs"
+                mountPath: "/my-service-logs"
+
+        volumes:
+          - name: "iptables-logs"
+            hostPath: 
+              # absolute path of the directory containing iptables log file on your host
+              path: "/var/log"
+          - name: "service-logs"
+            emptyDir: {}

--- a/kubernetes-debug/kit/netperf-calico-policy.yaml
+++ b/kubernetes-debug/kit/netperf-calico-policy.yaml
@@ -1,0 +1,20 @@
+apiVersion: crd.projectcalico.org/v1
+kind: NetworkPolicy
+metadata:
+  name: netperf-calico-policy
+  labels:
+spec:
+  order: 10
+  selector: app == "netperf-operator"
+  ingress:
+    - action: Allow
+      source:
+        selector: netperf-role == "netperf-client"
+    - action: Log
+    - action: Deny
+  egress:
+    - action: Allow
+      destination:
+        selector: netperf-role == "netperf-client"
+    - action: Log
+    - action: Deny

--- a/kubernetes-debug/kit/sa/sa.yaml
+++ b/kubernetes-debug/kit/sa/sa.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-iptables-tailer
+  namespace: kube-system
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-iptables-tailer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-iptables-tailer
+subjects:
+- kind: ServiceAccount
+  name: kube-iptables-tailer
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kube-iptables-tailer
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs:     ["list","get","watch"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs:     ["patch","create"]


### PR DESCRIPTION
 <details><summary>ДЗ № 13</summary>

 - [V] Основное ДЗ
 - [ ] Задание со *

- [V] Работа c kubectl-debug:
Не работает strace ,потому что необходимо добавлять разрешения для ptrace в контейнере  --cap-add=SYS_PTRACE (в Docker 19.3 системные вызовы ptrace разрешены);
В манифесте kubectl-debug  из ДЗ стоит версия дебаг пода -  0.0.1 ,где  не выставлено данное разрешение;
Можно  заменить на версию 0.1.1 где применен данный коммит:
```
		UsernsMode:  container.UsernsMode(m.containerMode(targetId)),
		IpcMode:     container.IpcMode(m.containerMode(targetId)),
		PidMode:     container.PidMode(m.containerMode(targetId)),
		CapAdd:      strslice.StrSlice([]string{"SYS_PTRACE", "SYS_ADMIN"}),
	}
	ctx, cancel := m.getContextWithTimeout()
	defer cancel()
  ```
- [V] установил оператор netperf-operator и тестовый cr kubectl apply -f /kit/deploy-netperf:
```
Name:         example
Namespace:    test
Labels:       <none>
Annotations:  <none>
API Version:  app.example.com/v1alpha1
Kind:         Netperf
Metadata:
  Creation Timestamp:  2021-03-21T13:37:20Z
  Generation:          4
  Managed Fields:
    API Version:  app.example.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:annotations:
          .:
          f:kubectl.kubernetes.io/last-applied-configuration:
    Manager:      kubectl-client-side-apply
    Operation:    Update
    Time:         2021-03-21T13:37:20Z
    API Version:  app.example.com/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:spec:
        .:
        f:clientNode:
        f:serverNode:
      f:status:
        .:
        f:clientPod:
        f:serverPod:
        f:speedBitsPerSec:
        f:status:
    Manager:         netperf-operator
    Operation:       Update
    Time:            2021-03-21T13:37:20Z
  Resource Version:  1736749
  Self Link:         /apis/app.example.com/v1alpha1/namespaces/test/netperfs/example
  UID:               195e3ad8-9c3e-4750-8b54-f21dbc2b464a
Spec:
  Client Node:
  Server Node:
Status:
  Client Pod:          netperf-client-f21dbc2b464a
  Server Pod:          netperf-server-f21dbc2b464a
  Speed Bits Per Sec:  1875.14
  Status:              Done
Events:                <none>
```
- [V] Добавляем сетевую политику calico -  kubectl apply -f netperf-calico-policy.yaml:
```
sudo iptables --list -nv | grep LOG
    0     0 LOG        all  --  *      *       0.0.0.0/0            0.0.0.0/0            /* cali:XWC9Bycp2Xf7yVk1 */ LOG flags 0 level 5 prefix "calico-packet: "
    9   540 LOG        all  --  *      *       0.0.0.0/0            0.0.0.0/0            /* cali:B30DykF1ntLW86eD */ LOG flags 0 level 5 prefix "calico-packet: "
```
- [V] Запускаем iptables-tailer, kubectl apply -f iptables-tailer.yaml -( необходимо доработать предоставленный манифест так как extensions/v1beta1 deprecated ):
- [V] Появились ошибки account :
````
kube-system   4m5s        Warning   FailedCreate        daemonset/kube-iptables-tailer                 Error creating: pods "kube-iptables-tailer-" is forbidden: error looking up service account kube-system/kube-iptables-tailer: serviceaccount "kube-iptables-tailer" not found
````
Создадим SA -kubectl apply  -f sa.yaml;
- [V] Изменим префикс PTABLES_LOG_PREFIX на calico-packet и  JOURNAL_DIRECTORY на /var/log/journal;
- [V] Перезапустим тесты и увидим результат :
```
Events:
  Type     Reason      Age   From                  Message
  ----     ------      ----  ----                  -------
  Normal   Scheduled   26s   default-scheduler     Successfully assigned test/netperf-server-36acf46d0825 to gke-serious-energy-serious-energy-nod-9289b5e6-igkc
  Normal   Pulling     25s   kubelet               Pulling image "tailoredcloud/netperf:v2.7"
  Normal   Pulled      22s   kubelet               Successfully pulled image "tailoredcloud/netperf:v2.7"
  Normal   Created     22s   kubelet               Created container netperf-server-36acf46d0825
  Normal   Started     22s   kubelet               Started container netperf-server-36acf46d0825
  Warning  PacketDrop  18s   kube-iptables-tailer  Packet dropped when receiving traffic from 10.84.2.10
  ```

## PR checklist:
 - [ ] Выставлен label с темой домашнего задания
